### PR TITLE
travis-ci: only build master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ julia:
   - release
   - nightly
 
+branches:
+  only:
+    - master
+
 notifications:
   email: false
 


### PR DESCRIPTION
This should prevent TravisCI from double-building feature branches and pull requests.