### PR TITLE
Add counters to LineModel

### DIFF
--- a/src/bmark/bmark_solvers.jl
+++ b/src/bmark/bmark_solvers.jl
@@ -42,7 +42,7 @@ if Pkg.installed("BenchmarkProfiles") != nothing
   #### Return value
   A profile as returned by `performance_profile()`.
   """
-  function profile_solvers(stats :: Dict{Symbol, Array{Int,2}}; kwargs...)
+  function profile_solvers{T,n}(stats :: Dict{Symbol, Array{T,n}}; kwargs...)
     args = Dict(kwargs)
     if haskey(args, :title)
       args[:title] *= @sprintf(" (%d problems)", size(stats[first(keys(stats))], 1))

--- a/src/linesearch/line_modelOpt.jl
+++ b/src/linesearch/line_modelOpt.jl
@@ -1,7 +1,7 @@
 importall NLPModels
 
 export LineModel
-export obj, grad, derivative, grad!, derivative!, hess, redirect!
+export obj, grad, derivative, grad!, derivative!, hess
 
 """A type to represent the restriction of a function to a direction.
 Given f : R → Rⁿ, x ∈ Rⁿ and a nonzero direction d ∈ Rⁿ,
@@ -38,11 +38,8 @@ end
 
     ϕ(t) := f(x + td).
 """
-#obj(f :: LineModel, t :: Float64) = obj(f.nlp, f.x + t * f.d)
-function obj(f :: LineModel, t :: Float64)
-    f.counters.neval_obj += 1
-    return obj(f.nlp, f.x + t * f.d)
-end
+obj(f :: LineModel, t :: Float64) = obj(f.nlp, f.x + t * f.d)
+
 
 """`grad(f, t)` evaluates the first derivative of the `LineModel`
 
@@ -52,11 +49,7 @@ i.e.,
 
     ϕ'(t) = ∇f(x + td)ᵀd.
 """
-#grad(f :: LineModel, t :: Float64) = dot(grad(f.nlp, f.x + t * f.d), f.d)
-function grad(f :: LineModel, t :: Float64)
-    f.counters.neval_grad += 1
-    return dot(grad(f.nlp, f.x + t * f.d), f.d)
-end
+grad(f :: LineModel, t :: Float64) = dot(grad(f.nlp, f.x + t * f.d), f.d)
 derivative(f :: LineModel, t :: Float64) = grad(f, t)
 
 """`grad!(f, t, g)` evaluates the first derivative of the `LineModel`
@@ -69,11 +62,7 @@ i.e.,
 
 The gradient ∇f(x + td) is stored in `g`.
 """
-#grad!(f :: LineModel, t :: Float64, g :: Vector{Float64}) = dot(grad!(f.nlp, f.x + t * f.d, g), f.d)
-function grad!(f :: LineModel, t :: Float64, g :: Vector{Float64})
-    f.counters.neval_grad += 1
-    return dot(grad!(f.nlp, f.x + t * f.d, g), f.d)
-end
+grad!(f :: LineModel, t :: Float64, g :: Vector{Float64}) = dot(grad!(f.nlp, f.x + t * f.d, g), f.d)
 derivative!(f :: LineModel, t :: Float64, g :: Vector{Float64}) = grad!(f, t, g)
 
 """Evaluate the second derivative of the `LineModel`
@@ -84,8 +73,4 @@ i.e.,
 
     ϕ"(t) = dᵀ∇²f(x + td)d.
 """
-#hess(f :: LineModel, t :: Float64) = dot(f.d, hprod(f.nlp, f.x + t * f.d, f.d))
-function hess(f :: LineModel, t :: Float64)
-    f.counters.neval_hess += 1
-    return dot(f.d, hprod(f.nlp, f.x + t * f.d, f.d))
-end
+hess(f :: LineModel, t :: Float64) = dot(f.d, hprod(f.nlp, f.x + t * f.d, f.d))


### PR DESCRIPTION
Useful when testing LineSearch algorithms to distinguish counts specific to the linesearch computation.