### PR TITLE
Updates to benchmark script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ notifications:
   email: false
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update && brew install gcc; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update && brew cask uninstall --force oclint && brew install gcc; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     wget --no-check-certificate http://www.cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz;
     tar -xzf cmake-3.3.2-Linux-x86_64.tar.gz;

--- a/examples/benchmark.jl
+++ b/examples/benchmark.jl
@@ -21,7 +21,7 @@ ampl_probs = filter(x -> contains(x, ".nl"), readdir(ampl_prob_dir))
 
 # Example 1: benchmark two solvers on a set of problems
 function two_solvers()
-  solvers = [trunk, lbfgs]
+  solvers = Dict{Symbol,Function}(:trunk => trunk, :lbfgs => lbfgs)
   bmark_args = Dict{Symbol, Any}(:skipif => model -> !unconstrained(model))
   profile_args = Dict{Symbol, Any}(:title => "f+g+hprod")
   bmark_and_profile(solvers,

--- a/src/bmark/bmark_solvers.jl
+++ b/src/bmark/bmark_solvers.jl
@@ -16,16 +16,17 @@ Any keyword argument accepted by `solve_problems()`
 #### Return value
 A Dict{Symbol, Array{Int,2}} of statistics.
 """
-function bmark_solvers(solvers :: Vector{Function}, args...; kwargs...)
+function bmark_solvers(solvers :: Dict{Symbol,Function}, args...; kwargs...)
   stats = Dict{Symbol, Array{Int,2}}()
-  for solver in solvers
-    stats[Symbol(solver)] = solve_problems(solver, args...; kwargs...)
+  for (name, solver) in solvers
+    stats[name] = solve_problems(solver, args...; kwargs...)
   end
   return stats
 end
 
 
 profile_solvers(args...; kwargs...) = error("BenchmarkProfiles is required for profiles")
+bmark_and_profile(args...; kwargs...) = error("BenchmarkProfiles is required for profiles")
 
 @require BenchmarkProfiles begin
   """

--- a/src/bmark/run_solver.jl
+++ b/src/bmark/run_solver.jl
@@ -84,6 +84,7 @@ function solve_problems(solver :: Function, problems :: Any; prune :: Bool=true,
     catch e
       isa(e, SkipException) || rethrow(e)
     end
+    finalize(problem)
   end
   solverlogger.level = current_level
   return prune ? stats[1:k, :] : stats

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,10 +11,10 @@ models = [simple_dixmaanj(),
   using CUTEst
   push!(models, CUTEstModel("DIXMAANJ", "-param", "M=30"))
 end
-solvers = [trunk, lbfgs, tron]
+solvers = Dict{Symbol,Function}(:trunk => trunk, :lbfgs => lbfgs, :tron => tron)
 
 for model in models
-  for solver in solvers
+  for (name, solver) in solvers
     stats = solve_problem(solver, model, verbose=false)
     assert(all([stats...] .>= 0))
     reset!(model)
@@ -29,11 +29,11 @@ probs = [dixmaane, dixmaanf, dixmaang, dixmaanh, dixmaani, dixmaanj, hs7]
 models = (MathProgNLPModel(p(99), name=string(p)) for p in probs)
 stats = bmark_solvers(solvers, models, skipif=m -> m.meta.ncon > 0)
 println(stats)
-println(size(stats[Symbol(solvers[1])], 1))
+println(size(stats[:trunk], 1))
 println(length(probs))
-assert(size(stats[Symbol(solvers[1])], 1) == length(probs) - 1)
+assert(size(stats[:trunk], 1) == length(probs) - 1)
 stats = bmark_solvers(solvers, models, skipif=m -> m.meta.ncon > 0, prune=false)
-assert(size(stats[Symbol(solvers[1])], 1) == length(probs))
+assert(size(stats[:trunk], 1) == length(probs))
 
 # test bmark_solvers with CUTEst
 @static if is_unix()
@@ -44,4 +44,3 @@ end
 
 # Test TRON
 include("solvers/tron.jl")
-


### PR DESCRIPTION
The set of solvers to benchmark should now be a `Dict{Symbol,Function}`. The symbols are used to index the `stats` dictionary and as labels in a performance profile legend. This is necessary in case solvers are defined by anonymous functions (which have names such as `#12`).