### PR TITLE
Use stats on solvers

### DIFF
--- a/src/bmark/bmark_solvers.jl
+++ b/src/bmark/bmark_solvers.jl
@@ -1,6 +1,8 @@
-export bmark_solvers, profile_solvers, bmark_and_profile
+export bmark_solvers, profile_solvers,
+       bmark_and_profile
 
 
+optimizelogger = get_logger("optimize")
 """
     bmark_solvers(solvers :: Vector{Function}, args...; kwargs...)
 
@@ -14,11 +16,13 @@ Run a set of solvers on a set of problems.
 Any keyword argument accepted by `solve_problems()`
 
 #### Return value
-A Dict{Symbol, Array{Int,2}} of statistics.
+A Dict{Symbol, AbstractExecutionStats} of statistics.
 """
 function bmark_solvers(solvers :: Dict{Symbol,Function}, args...; kwargs...)
-  stats = Dict{Symbol, Array{Int,2}}()
-  for (name, solver) in solvers
+  stats = Dict{Symbol, Array{AbstractExecutionStats,1}}()
+  for (name,solver) in solvers
+    @info(optimizelogger,
+          @printf("running %s\n", string(solver)))
     stats[name] = solve_problems(solver, args...; kwargs...)
   end
   return stats
@@ -38,24 +42,40 @@ bmark_and_profile(args...; kwargs...) = error("BenchmarkProfiles is required for
   * `stats`: a dict of statistics such as obtained from `bmark_solvers()`
 
   #### Keyword arguments
-  Any keyword argument accepted by `BenchmarkProfiles.performance_profile()`.
+  * `cost`: a function `cost(::AbstractExecutionStats)` returning a positive cost
+    value. Usually, time or number of function evaluations.
+  * Any keyword argument accepted by `BenchmarkProfiles.performance_profile()`.
 
   #### Return value
   A profile as returned by `performance_profile()`.
+
+  #### Cost functions
+
+  The default cost function is the number of function evaluations, i.e.,
+
+      cost = stat->sum_counters(stat.counters)
+
+  Another commonly used option is the elapsed time:
+
+      cost = stat->stat.elapsed_time
   """
-  function profile_solvers{T,n}(stats :: Dict{Symbol, Array{T,n}}; kwargs...)
+  function profile_solvers(stats :: Dict{Symbol, Array{AbstractExecutionStats,1}};
+                           cost :: Function = stat->sum_counters(stat.counters),
+                           kwargs...)
     args = Dict(kwargs)
     if haskey(args, :title)
       args[:title] *= @sprintf(" (%d problems)", size(stats[first(keys(stats))], 1))
     end
-    BenchmarkProfiles.performance_profile(hcat([sum(p, 2) for p in values(stats)]...),
-                                          collect(String, [string(s) for s in keys(stats)]); args...)
+    solvers = keys(stats)
+    np, ns = length(stats[first(solvers)]), length(solvers)
+    P = [stats[s][p].status == :first_order ? cost(stats[s][p]) : -1 for p = 1:np, s in solvers]
+    BenchmarkProfiles.performance_profile(P, map(string, solvers); args...)
   end
 
   """
       bmark_and_profile(args...;
-                        bmark_args :: Dict{Symbol, Any}=Dict{Symbol,Any}(),
-                        profile_args :: Dict{Symbol, Any}=Dict{Symbol,Any}())
+                        bmark_args :: Dict{Symbol, <: Any}=Dict{Symbol,Any}(),
+                        profile_args :: Dict{Symbol, <: Any}=Dict{Symbol,Any}())
 
   Run a set of solvers on a set of problems and plot a performance profile.
 
@@ -69,12 +89,22 @@ bmark_and_profile(args...; kwargs...) = error("BenchmarkProfiles is required for
   #### Return value
   * A Dict{Symbol, Array{Int,2}} of statistics
   * a profile as returned by `performance_profile()`.
+
+  #### Cost functions
+
+  The default cost function is the number of function evaluations, i.e.,
+
+      cost = stat->sum_counters(stat.counters)
+
+  Another commonly used option is the elapsed time:
+
+      cost = stat->stat.elapsed_time
   """
-  function bmark_and_profile(args...;
-                             bmark_args :: Dict{Symbol, Any}=Dict{Symbol,Any}(),
-                             profile_args :: Dict{Symbol, Any}=Dict{Symbol,Any}())
+  @compat function bmark_and_profile(args...; cost :: Function = stat->sum_counters(stat.counters),
+                             bmark_args :: Dict{Symbol, <: Any}=Dict{Symbol,Any}(),
+                             profile_args :: Dict{Symbol, <: Any}=Dict{Symbol,Any}())
     stats = bmark_solvers(args...; bmark_args...)
-    profiles = profile_solvers(stats; profile_args...)
+    profiles = profile_solvers(stats, cost=cost; profile_args...)
     return stats, profiles
   end
 end

--- a/test/solvers/tron.jl
+++ b/test/solvers/tron.jl
@@ -43,11 +43,11 @@ end
 
     nlp = ADNLPModel(f, x0, lvar=[-Inf; -Inf], uvar=[Inf; Inf])
 
-    x, fx, π, iter, optimal, tired, status = tron(nlp)
-    @test isapprox(x, zeros(2), rtol=1e-6)
-    @test isapprox(fx, 0.0, rtol=1e-12)
-    @test π < 1e-6
-    @test optimal == true
+    stats = tron(nlp)
+    @test isapprox(stats.solution, zeros(2), rtol=1e-6)
+    @test isapprox(stats.objective, 0.0, rtol=1e-12)
+    @test stats.dual_feas < 1e-6
+    @test stats.status == :first_order
   end
 
   @testset "Bounds" begin
@@ -58,11 +58,11 @@ end
 
     nlp = ADNLPModel(f, x0, lvar=l, uvar=u)
 
-    x, fx, π, iter, optimal, tired, status = tron(nlp)
-    @test x ≈ l
-    @test fx == f(l)
-    @test π < 1e-6
-    @test optimal == true
+    stats = tron(nlp)
+    @test stats.solution ≈ l
+    @test stats.objective == f(l)
+    @test stats.dual_feas < 1e-6
+    @test stats.status == :first_order
   end
 
   @testset "Rosenbrock" begin
@@ -71,11 +71,11 @@ end
 
     nlp = ADNLPModel(f, x0)
 
-    x, fx, π, iter, optimal, tired, status = tron(nlp)
-    @test isapprox(x, [1.0;1.0], rtol=1e-3)
-    @test isapprox(fx, 1.0, rtol=1e-5)
-    @test π < 1e-6
-    @test optimal == true
+    stats = tron(nlp)
+    @test isapprox(stats.solution, [1.0;1.0], rtol=1e-3)
+    @test isapprox(stats.objective, 1.0, rtol=1e-5)
+    @test stats.dual_feas < 1e-6
+    @test stats.status == :first_order
   end
 
   @testset "Rosenbrock inactive bounds" begin
@@ -86,11 +86,11 @@ end
 
     nlp = ADNLPModel(f, x0, lvar=l, uvar=u)
 
-    x, fx, π, iter, optimal, tired, status = tron(nlp)
-    @test isapprox(x, [1.0;1.0], rtol=1e-3)
-    @test isapprox(fx, 1.0, rtol=1e-5)
-    @test π < 1e-6
-    @test optimal == true
+    stats = tron(nlp)
+    @test isapprox(stats.solution, [1.0;1.0], rtol=1e-3)
+    @test isapprox(stats.objective, 1.0, rtol=1e-5)
+    @test stats.dual_feas < 1e-6
+    @test stats.status == :first_order
   end
 
   @testset "Rosenbrock active bounds" begin
@@ -103,11 +103,11 @@ end
 
     sol = [0.9; 0.81]
 
-    x, fx, π, iter, optimal, tired, status = tron(nlp)
-    @test isapprox(x, sol, rtol=1e-3)
-    @test isapprox(fx, f(sol), rtol=1e-5)
-    @test π < 1e-6
-    @test optimal == true
+    stats = tron(nlp)
+    @test isapprox(stats.solution, sol, rtol=1e-3)
+    @test isapprox(stats.objective, f(sol), rtol=1e-5)
+    @test stats.dual_feas < 1e-6
+    @test stats.status == :first_order
   end
 end
 
@@ -118,11 +118,11 @@ end
     u = [1.0; 2.0; 2.0]
     f(x) = 0.5*dot(x - 3, x - 3)
     nlp = ADNLPModel(f, x0, lvar=l, uvar=u)
-    x, fx, π, iter, optimal, tired, status = tron(nlp)
-    @test optimal == true
-    @test π < 1e-6
-    @test isapprox(x, [1.0; 2.0; 2.0], rtol=1e-3)
-    @test x[1] == 1.0
+    stats = tron(nlp)
+    @test stats.status == :first_order
+    @test stats.dual_feas < 1e-6
+    @test isapprox(stats.solution, [1.0; 2.0; 2.0], rtol=1e-3)
+    @test stats.solution[1] == 1.0
   end
 
   @testset "All fixed" begin
@@ -132,10 +132,10 @@ end
     u = copy(l)
     f(x) = sum(x.^4)
     nlp = ADNLPModel(f, x0, lvar=l, uvar=u)
-    x, fx, π, iter, optimal, tired, status = tron(nlp)
-    @test optimal == true
-    @test π == 0.0
-    @test x == l
+    stats = tron(nlp)
+    @test stats.status == :first_order
+    @test stats.dual_feas == 0.0
+    @test stats.solution == l
   end
 end
 
@@ -154,12 +154,12 @@ end
 
       nlp = ADNLPModel(f, x0)
 
-      x, fx, π, iter, optimal, tired, status = tron(nlp)
+      stats = tron(nlp)
       normg0 = norm(B*(x0-r))
-      @test norm(x - r) < 1e-4 * normg0
-      @test isapprox(fx, 1.0, rtol=1e-6)
-      @test π < 1e-6 * normg0
-      @test optimal == true
+      @test norm(stats.solution - r) < 1e-4 * normg0
+      @test isapprox(stats.objective, 1.0, rtol=1e-6)
+      @test stats.dual_feas < 1e-6 * normg0
+      @test stats.status == :first_order
     end
   end
 
@@ -186,15 +186,15 @@ end
 
       nlp = ADNLPModel(f, x0, lvar=l, uvar=u)
 
-      x, fx, π, iter, optimal, tired, status = tron(nlp)
+      stats = tron(nlp)
       normg0 = norm(B*(x0-r))
 
-      @test norm(x - r) < 1e-3
-      @test isapprox(fx, f(r), rtol=1e-4)
-      @test π < 1e-4
-      @test optimal == true
-      @test iter <= 10000
-      @test status == "first-order stationary"
+      @test norm(stats.solution - r) < 1e-3
+      @test isapprox(stats.objective, f(r), rtol=1e-4)
+      @test stats.dual_feas < 1e-4
+      @test stats.status == :first_order
+      @test stats.iter <= 10000
+      @test stats.status == :first_order
     end
   end
 end
@@ -210,15 +210,15 @@ end
   nlp = ADNLPModel(f, x0)
 
   @testset "Iteration limit" begin
-    x, fx, π, iter, optimal, tired, status = tron(nlp, itmax=1)
-    @test iter == 1
-    @test tired == true
+    stats = tron(nlp, itmax=1)
+    @test stats.iter == 1
+    @test stats.status == :max_iter
   end
 
   @testset "Time limit" begin
-    x, fx, π, iter, optimal, tired, status, el_time = tron(nlp, timemax=0)
-    @test el_time > 0
-    @test tired == true
+    stats = tron(nlp, timemax=0)
+    @test stats.elapsed_time > 0
+    @test stats.status == :max_time
   end
 
   @testset "x0 outside box" begin
@@ -226,11 +226,11 @@ end
     u = l + rand(n)
     x0 = u + rand(n)
     nlp = ADNLPModel(x->dot(x,x), x0, lvar=l, uvar=u)
-    x, fx, π, iter, optimal, tired, status = tron(nlp)
-    @test norm(x - l) < 1e-3
-    @test isapprox(fx, dot(l,l), rtol=1e-5)
-    @test π < 1e-4
-    @test optimal == true
+    stats = tron(nlp)
+    @test norm(stats.solution - l) < 1e-3
+    @test isapprox(stats.objective, dot(l,l), rtol=1e-5)
+    @test stats.dual_feas < 1e-4
+    @test stats.status == :first_order
   end
 end
 
@@ -247,33 +247,34 @@ end
 
   nlp = ADNLPModel(f, x0)
 
-  x, fx, π, iter, optimal, tired, status = tron(nlp, timemax=600)
-  @test isapprox(x, ones(n), rtol=1e-5*n)
-  @test isapprox(fx, 1.0, rtol=1e-3)
-  @test π < 1e-3*n
-  @test optimal == true
+  stats = tron(nlp, timemax=600)
+  @test isapprox(stats.solution, ones(n), rtol=1e-5*n)
+  @test isapprox(stats.objective, 1.0, rtol=1e-3)
+  @test stats.dual_feas < 1e-3*n
+  @test stats.status == :first_order
 
   nlp = ADNLPModel(f, x0, lvar=zeros(n), uvar=0.3*ones(n))
 
-  x, fx, π, iter, optimal, tired, status = tron(nlp, timemax=600)
-  @test π < 1e-3*n
-  @test optimal == true
+  stats = tron(nlp, timemax=600)
+  @test stats.dual_feas < 1e-3*n
+  @test stats.status == :first_order
 end
 
 @static if is_unix()
   @testset "CUTEst" begin
     problems = CUTEst.select(max_var=10, max_con=0, only_bnd_var=true)
-    @printf("%8s  %5s  %4s  %9s  %9s  %9s  %6s  %6s  %6s  %6s  %s\n",
-            "Problem", "n", "type", "f(x)", "π", "time", "it", "#f", "#g", "#Hp", "status")
+    stline = statshead([:objective, :dual_feas, :elapsed_time, :iter, :neval_obj,
+                        :neval_grad, :neval_hprod, :status])
+    @printf("%8s  %5s  %4s  %s\n", "Problem", "n", "type", stline)
     for p in problems
       nlp = CUTEstModel(p)
-      x, fx, π, iter, optimal, tired, status, el_time = tron(nlp, timemax=3.0)
+      stats = tron(nlp, timemax=3.0)
       finalize(nlp)
 
       ctype = length(nlp.meta.ifree) == nlp.meta.nvar ? "unc" : "bnd"
-      @printf("%8s  %5d  %4s  %9.2e  %9.2e  %9.2e  %6d  %6d  %6d  %6d  %s\n", p,
-              nlp.meta.nvar, ctype, fx, π, el_time, iter, neval_obj(nlp), neval_grad(nlp),
-              neval_hprod(nlp), status)
+      stline = statsline(stats, [:objective, :dual_feas, :elapsed_time, :iter, :neval_obj,
+                                 :neval_grad, :neval_hprod, :status])
+      @printf("%8s  %5d  %4s  %s\n", p, nlp.meta.nvar, ctype, stline)
     end
   end
 end

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -1,3 +1,5 @@
+using Base.Test
+
 function test_stats()
   nlp = ADNLPModel(x->dot(x,x), zeros(2))
   stats = GenericExecutionStats(:first_order, nlp, objective=1.0, dual_feas=1e-12,
@@ -26,6 +28,8 @@ function test_stats()
   end
   println(statshead(line))
   println(statsline(stats, line))
+
+  @test_throws Exception GenericExecutionStats(:unkwown, nlp, bad=true)
 end
 
 test_stats()


### PR DESCRIPTION
Finalizing the `ExecutionStats` migration, this changes the current solvers to use the new stats. The benchmark and profile tools are updated as well.
Unfortunately, it's a large PR, in line counts.