### PR TITLE
Logging update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,18 @@ os:
 julia:
   - 0.7
   - 1.0
+  - 1.1
   - nightly
 
 matrix:
   allow_failures:
     - julia: nightly
+
+notifications:
+  email:
+    recipients: abel.s.siqueira@gmail.com
+    on_success: never
+    on_failure: change
 
 addons:
   apt_packages:
@@ -20,9 +27,7 @@ addons:
 branches:
   only:
     - master
-
-notifications:
-  email: false
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/ # tags
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update && brew cask uninstall --force oclint && brew install gcc; brew tap optimizers/cutest; brew install cutest; brew install mastsif; for f in "archdefs" "sifdecode" "mastsif" "cutest"; do source $(brew --prefix $f)/$f.bashrc; done; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,22 @@
 environment:
   matrix:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0-latest-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1.0
+  - julia_version: 1.1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
 
 matrix:
   allow_failures:
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: nightly
+
+branches:
+  only:
+    - master
+    - /release-.*/
 
 notifications:
   - provider: Email
@@ -18,25 +24,13 @@ notifications:
     on_build_failure: false
     on_build_status_changed: false
 
-branches:
-  only:
-    - master
-
-skip_branch_with_pr: true
-
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile($env:JULIA_URL, "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "using Pkg;
-      Pkg.add(PackageSpec(url=\"https://github.com/JuliaSmoothOptimizers/Krylov.jl\"));
-      Pkg.clone(pwd(), \"Optimize\"); Pkg.build(\"Optimize\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "using Pkg; pkg\"add https://github.com/JuliaSmoothOptimizers/Krylov.jl\"; %JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "using Pkg; Pkg.test(\"Optimize\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/src/Optimize.jl
+++ b/src/Optimize.jl
@@ -3,7 +3,7 @@ __precompile__(false)
 
 using NLPModels, NLPModelsJuMP, LinearOperators, Krylov, Requires
 using LinearAlgebra
-using Printf
+using Printf, Logging
 
 # Auxiliary.
 include("auxiliary/bounds.jl")

--- a/src/bmark/bmark_solvers.jl
+++ b/src/bmark/bmark_solvers.jl
@@ -15,11 +15,15 @@ Any keyword argument accepted by `solve_problems()`
 #### Return value
 A Dict{Symbol, AbstractExecutionStats} of statistics.
 """
-function bmark_solvers(solvers :: Dict{Symbol,Function}, args...; kwargs...)
+function bmark_solvers(solvers :: Dict{Symbol,Function}, args...;
+                       logger :: AbstractLogger=NullLogger(),
+                       kwargs...)
   stats = Dict{Symbol, DataFrame}()
   for (name,solver) in solvers
-    @info @sprintf("running %s\n", string(solver))
-    stats[name] = solve_problems(solver, args...; kwargs...)
+    with_logger(logger) do
+      @info @sprintf("running solver %s\n", string(solver))
+    end
+    stats[name] = solve_problems(solver, args...; logger=logger, kwargs...)
   end
   return stats
 end

--- a/src/bmark/run_solver.jl
+++ b/src/bmark/run_solver.jl
@@ -1,51 +1,6 @@
-export display_header, solve_problems, solve_problem, uncstats, constats
+export solve_problems
 
 using DataFrames
-
-struct SkipException <: Exception
-end
-
-const uncstats = [:objective, :dual_feas, :neval_obj, :neval_grad, :neval_hess, :neval_hprod, :iter, :elapsed_time, :status]
-const constats = [:objective, :dual_feas, :neval_obj, :neval_grad, :neval_hess, :neval_hprod, :neval_cons, :neval_jac, :neval_jprod, :neval_jtprod, :iter, :elapsed_time, :status]
-
-"""
-    display_header()
-
-Output header for stats table.
-
-This function is called once before the first problem solve and can be overridden to customize the display.
-
-#### Return value
-Nothing.
-"""
-function display_header(;colstats::Array{Symbol} = constats)
-  s = statshead(colstats)
-  @info @sprintf("%-15s  %8s  %8s  %s\n", "Name", "nvar", "ncon", s)
-end
-
-
-"""
-display_problem_stats(nlp, stats; colstats)
-
-Output stats for problem `nlp` after a solve.
-
-This function is called after each problem solve and can be overridden to customize the display.
-
-#### Arguments
-* `nlp::AbstractNLPModel`: the problem just solved
-* `stats::AbstractExecutionStats`: execution statistics
-* `colstats::Array{Symbol}`: list of desired stats to show
-
-#### Return value
-Nothing.
-"""
-function display_problem_stats(nlp::AbstractNLPModel,
-                               stats::AbstractExecutionStats;
-                               colstats::Array{Symbol} = constats)
-  s = statsline(stats, colstats)
-  @info @sprintf("%-15s  %8d  %8d  %s\n",
-                 nlp.meta.name, nlp.meta.nvar, nlp.meta.ncon, s)
-end
 
 """
     solve_problems(solver :: Function, problems :: Any; kwargs...)
@@ -54,74 +9,60 @@ Apply a solver to a set of problems.
 
 #### Arguments
 * `solver`: the function name of a solver
-* `problems`: the set of problems to pass to the solver, as an iterable of `AbstractNLPModel`
-  (it is recommended to use a generator expression)
+* `problems`: the set of problems to pass to the solver, as an iterable of
+  `AbstractNLPModel`.  It is recommended to use a generator expression (necessary for
+  CUTEst problems).
 
 #### Keyword arguments
+* `logger::AbstractLogger`: logger used to show the statistics. Recommended `NullLogger`
+  for nothing or `ConsoleLogger`. (default: `NullLogger`).
+* `skipif::Function`: function to be applied to a problem and return whether to skip it
+  (default: `x->false`)
 * `prune`: do not include skipped problems in the final statistics (default: `true`)
-* any other keyword argument accepted by `run_problem()`
+* any other keyword argument to be passed to the solvers
 
 #### Return value
-* an `Array(AbstractExecutionStats, nprobs)` where `nprobs` is the number of problems
-  in `problems` minus the skipped ones if `prune` is true.
+* a `DataFrame` where each line is a problem, minus the skipped ones if `prune` is true.
 """
-function solve_problems(solver :: Function, problems :: Any; prune :: Bool=true, kwargs...)
-  display_header()
+function solve_problems(solver :: Function, problems :: Any;
+                        logger :: AbstractLogger=NullLogger(),
+                        skipif :: Function=x->false,
+                        colstats :: Array{Symbol,1} = [:name, :nvar, :ncon, :status],
+                        prune :: Bool=true, kwargs...)
   nprobs = length(problems)
   solverstr = split(string(solver), ".")[end]
 
   counter_fields = collect(fieldnames(Counters))
-  types = [String;  Symbol;    Float64;       Float64;   Int;    Float64; fill(Int, length(counter_fields))]
-  names = [ :name; :status; :objective; :elapsed_time; :iter; :dual_feas;                    counter_fields]
+  ncounters = length(counter_fields)
+  types = [Int; String;   Int;   Int;  Symbol;    Float64;       Float64;   Int;    Float64; fill(Int, ncounters)]
+  names = [:id;  :name; :nvar; :ncon; :status; :objective; :elapsed_time; :iter; :dual_feas;                    counter_fields]
   stats = DataFrame(types, names, 0)
 
-  k = 0
-  for problem in problems
+  with_logger(logger) do
+    # TODO: Improve logging after #74
+    @info join(string.(colstats), "  ")
+  end
+
+  for (id,problem) in enumerate(problems)
+    problem_info = [id; problem.meta.name; problem.meta.nvar; problem.meta.ncon]
+    if skipif(problem)
+      prune || push!(stats, [problem_info; :exception; Inf; Inf; 0; Inf; fill(0, ncounters)])
+      finalize(problem)
+      continue
+    end
     try
-      s = solve_problem(solver, problem; kwargs...)
-      push!(stats, [problem.meta.name; s.status; s.objective; s.elapsed_time; s.iter; s.dual_feas;
+      s = solver(problem; kwargs...)
+      push!(stats, [problem_info; s.status; s.objective; s.elapsed_time; s.iter; s.dual_feas;
                     [getfield(s.counters, f) for f in counter_fields]])
     catch e
-      isa(e, SkipException) || rethrow(e)
-      prune || push!(stats, [problem.meta.name; :exception; Inf; Inf; -1; Inf;
-                             fill(-1, length(counter_fields))])
+      push!(stats, [problem_info; :exception; Inf; Inf; 0; Inf;
+                    fill(0, ncounters)])
     finally
       finalize(problem)
     end
+    with_logger(logger) do
+      @info join(string.(Vector(stats[end,colstats])), "  ")
+    end
   end
-  return stats
-end
-
-
-"""
-    solve_problem(solver :: Function, nlp :: AbstractNLPModel; kwargs...)
-
-Apply a solver to a generic `AbstractNLPModel`.
-
-#### Arguments
-* `solver`: the function name of a solver, as a symbol
-* `nlp`: an `AbstractNLPModel` instance
-
-#### Keyword arguments
-Any keyword argument accepted by the solver.
-
-#### Return value
-* an array `[f, g, h]` representing the number of objective evaluations, the number
-  of gradient evaluations and the number of Hessian-vector products required to solve
-  `nlp` with `solver`.
-  Negative values are used to represent failures.
-"""
-function solve_problem(solver :: Function, nlp :: AbstractNLPModel; colstats::Array{Symbol} = constats, kwargs...)
-  args = Dict(kwargs)
-  skip = haskey(args, :skipif) ? pop!(args, :skipif) : x -> false
-  skip(nlp) && throw(SkipException())
-
-  stats = GenericExecutionStats(:exception, nlp)
-  # try
-    stats = solver(nlp; args...)
-  # catch e
-  #   status = :msg in fieldnames(typeof(e)) ? e.msg : string(e)
-  # end
-  display_problem_stats(nlp, stats, colstats=colstats)
   return stats
 end

--- a/src/solver/tron.jl
+++ b/src/solver/tron.jl
@@ -18,6 +18,7 @@ Chih-Jen Lin and Jorge J. Moré, *Newton's Method for Large Bound-Constrained
 Optimization Problems*, SIAM J. Optim., 9(4), 1100–1127, 1999.
 """
 function tron(nlp :: AbstractNLPModel;
+              logger :: AbstractLogger=NullLogger(),
               μ₀ :: Real=1e-2,
               μ₁ :: Real=1.0,
               σ :: Real=10.0,
@@ -64,10 +65,12 @@ function tron(nlp :: AbstractNLPModel;
 
   αC = 1.0
   tr = TRONTrustRegion(min(max(1.0, 0.1 * norm(πx)), 100))
-  @info @sprintf("%4s  %9s  %7s  %7s  %7s  %s",
-                 "Iter", "f", "π", "Radius", "Ratio", "CG-status")
-  @info @sprintf("%4d  %9.2e  %7.1e  %7.1e",
-                 iter, fx, πx, get_property(tr, :radius))
+  with_logger(logger) do
+    @info @sprintf("%4s  %9s  %7s  %7s  %7s  %s",
+                   "Iter", "f", "π", "Radius", "Ratio", "CG-status")
+    @info @sprintf("%4d  %9.2e  %7.1e  %7.1e",
+                   iter, fx, πx, get_property(tr, :radius))
+  end
   while !(optimal || tired || stalled || unbounded)
     # Current iteration
     xc .= x
@@ -125,8 +128,10 @@ function tron(nlp :: AbstractNLPModel;
     optimal = πx <= ϵ
     unbounded = fx < fmin
 
-    @info @sprintf("%4d  %9.2e  %7.1e  %7.1e  %7.1e  %s",
-                   iter, fx, πx, Δ, tr.ratio, cginfo)
+    with_logger(logger) do
+      @info @sprintf("%4d  %9.2e  %7.1e  %7.1e  %7.1e  %s",
+                     iter, fx, πx, Δ, tr.ratio, cginfo)
+    end
   end
 
   if tired

--- a/src/stats/stats.jl
+++ b/src/stats/stats.jl
@@ -94,7 +94,7 @@ println(io :: IO, stats :: GenericExecutionStats; showvec ::
 println(stats :: GenericExecutionStats; showvec :: Function=disp_vector) =
     print(Base.stdout, stats, showvec=showvec)
 
-const headsym = Dict(:status  => "  Status",
+const headsym = Dict(:status       => "  Status",
                      :iter         => "   Iter",
                      :neval_obj    => "   #obj",
                      :neval_grad   => "  #grad",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,8 +30,9 @@ trunk(nlp, logger=ConsoleLogger())
 @info("Logging of calling solve_problems with trunk")
 nlp2 = ADNLPModel(x -> x[1]^4 + x[2]^4, ones(2), name="sumquartic")
 solve_problems(trunk, [nlp, nlp2], logger=ConsoleLogger())
-@info("Logging of calling solve_problems with trunk and colstats")
-solve_problems(trunk, [nlp, nlp2], logger=ConsoleLogger(), colstats=[:name, :objective])
+@info("Logging of calling solve_problems with trunk and colstats and solver logger")
+solve_problems(trunk, [nlp, nlp2], logger=ConsoleLogger(),
+               solver_logger=ConsoleLogger(), colstats=[:name, :objective])
 @info("Done")
 
 # test benchmark helpers, skip constrained problems (hs7 has constraints)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test, NLPModels, NLPModelsJuMP, OptimizationProblems, Optimize, LinearAlgebra,
-      SparseArrays
+      SparseArrays, Logging
 
 include("simple_dixmaanj.jl")
 
@@ -13,34 +13,44 @@ models = [simple_dixmaanj(),
 end
 solvers = Dict{Symbol,Function}(:trunk => trunk, :lbfgs => lbfgs, :tron => tron)
 
+@info("Testing various solvers in different models")
 for model in models
   for (name, solver) in solvers
-    println(solver)
-    stats = solve_problem(solver, model, colstats=uncstats)
-    println(stats)
-    @assert stats.status == :first_order
+    stats = solver(model)
+    @test stats.status == :first_order
     reset!(model)
   end
   finalize(model)
 end
+@info("Done")
+
+@info("Logging of calling trunk directly")
+nlp = ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - x[1]^2)^2, [-1.2; 1.0], name="rosen")
+trunk(nlp, logger=ConsoleLogger())
+@info("Logging of calling solve_problems with trunk")
+nlp2 = ADNLPModel(x -> x[1]^4 + x[2]^4, ones(2), name="sumquartic")
+solve_problems(trunk, [nlp, nlp2], logger=ConsoleLogger())
+@info("Logging of calling solve_problems with trunk and colstats")
+solve_problems(trunk, [nlp, nlp2], logger=ConsoleLogger(), colstats=[:name, :objective])
+@info("Done")
 
 # test benchmark helpers, skip constrained problems (hs7 has constraints)
-solve_problem(trunk, simple_dixmaanj(), monotone=false, colstats=uncstats)
+trunk(simple_dixmaanj(), monotone=false)
 probs = [dixmaane, dixmaanf, dixmaang, dixmaanh, dixmaani, dixmaanj, hs7]
 
 models = (MathProgNLPModel(p(99), name=string(p)) for p in probs)
-stats = bmark_solvers(solvers, models, skipif=m -> m.meta.ncon > 0, colstats=uncstats)
-@assert(size(stats[:trunk], 1) == length(probs) - 1)
+stats = bmark_solvers(solvers, models, skipif=m -> m.meta.ncon > 0)
+@test size(stats[:trunk], 1) == length(probs) - 1
 stats = bmark_solvers(solvers, models, skipif=m -> m.meta.ncon > 0, prune=false)
-@assert(size(stats[:trunk], 1) == length(probs))
+@test size(stats[:trunk], 1) == length(probs)
 
 # test bmark_solvers with CUTEst
 @static if Sys.isunix()
   using CUTEst
   models = (isa(p, String) ? CUTEstModel(p) : CUTEstModel(p...) for p in ["ROSENBR", ("DIXMAANJ", "-param", "M=30")])
-  stats = bmark_solvers(solvers, models)
+  stats = bmark_solvers(solvers, models, logger=ConsoleLogger())
   for s in keys(solvers)
-    @info "Solver $s"
+    @info "Example of Dataframe output: Solver $s"
     @info stats[s][[:name, :status, :objective, :elapsed_time, :neval_obj]]
   end
 end


### PR DESCRIPTION
- Solvers receive an option `logger`, and should log to that;
- solve_problem was removed because I don't think it was needed;
- solve_problems now has `skipif`, and also `logger`;
- solve_problems per iteration printing is "broken";
  - #75 is the required solution;
  - We lose real-time printing, because `df = solve_problems(...)` has all the information;
- Updated travis and appveyor