### PR TITLE
Update stats and bmark for NLSModels

### DIFF
--- a/src/bmark/run_solver.jl
+++ b/src/bmark/run_solver.jl
@@ -34,31 +34,46 @@ function solve_problems(solver :: Function, problems :: Any;
   nprobs = length(problems)
   solverstr = split(string(solver), ".")[end]
 
-  counter_fields = collect(fieldnames(Counters))
-  ncounters = length(counter_fields)
-  types = [Int; String;   Int;   Int;  Symbol;    Float64;       Float64;   Int;    Float64; fill(Int, ncounters); String]
-  names = [:id;  :name; :nvar; :ncon; :status; :objective; :elapsed_time; :iter; :dual_feas;                    counter_fields; :extrainfo]
+  f_counters = collect(fieldnames(Counters))
+  fnls_counters = collect(fieldnames(NLSCounters))[2:end] # Excludes :counters
+  ncounters = length(f_counters) + length(fnls_counters)
+  types = [Int; String;   Int;   Int;   Int;  Symbol;    Float64;       Float64;   Int;    Float64; fill(Int, ncounters); String]
+  names = [:id;  :name; :nvar; :ncon; :nequ; :status; :objective; :elapsed_time; :iter; :dual_feas; f_counters; fnls_counters; :extrainfo]
   stats = DataFrame(types, names, 0)
+
+  specific = Symbol[]
 
   with_logger(logger) do
     # TODO: Improve logging after #74
     @info join(string.(colstats), "  ")
   end
 
+  first_problem = true
   for (id,problem) in enumerate(problems)
-    problem_info = [id; problem.meta.name; problem.meta.nvar; problem.meta.ncon]
+    nequ = problem isa AbstractNLSModel ? problem.nls_meta.nequ : 0
+    problem_info = [id; problem.meta.name; problem.meta.nvar; problem.meta.ncon; nequ]
     if skipif(problem)
-      prune || push!(stats, [problem_info; :exception; Inf; Inf; 0; Inf; fill(0, ncounters); "skipped"])
+      prune || push!(stats, [problem_info; :exception; Inf; Inf; 0; Inf;
+                             fill(0, ncounters); "skipped"; fill(missing, length(specific))])
       finalize(problem)
       continue
     end
     try
       s = solver(problem; logger=solver_logger, kwargs...)
+      if first_problem
+        for (k,v) in s.solver_specific
+          insertcols!(stats, ncol(stats)+1, k => Array{Union{typeof(v),Missing},1}())
+          push!(specific, k)
+        end
+        first_problem = false
+      end
       push!(stats, [problem_info; s.status; s.objective; s.elapsed_time; s.iter; s.dual_feas;
-                    [getfield(s.counters, f) for f in counter_fields]; ""])
+                    [getfield(s.counters.counters, f) for f in f_counters];
+                    [getfield(s.counters, f) for f in fnls_counters]; "";
+                    [s.solver_specific[k] for k in specific]])
     catch e
       push!(stats, [problem_info; :exception; Inf; Inf; 0; Inf;
-                    fill(0, ncounters); string(e)])
+                    fill(0, ncounters); string(e); fill(missing, length(specific))])
     finally
       finalize(problem)
     end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 OptimizationProblems
+NLSProblems
 @unix CUTEst 0.2.0


### PR DESCRIPTION
- In `GenericExecutionStats`, `Counters` becomes `NLSCounters`, and all access to counters now need to check if is an `NLSCounters` or a `Counters`; (hopefully will change with NLPModels 1.0);
- Add all that to the DataFrames;